### PR TITLE
Add quotes PUT route for updating or creating statusType of a quote + ENTER key press event trigger on signin.html page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 brocePair.pem
+npm-debug.log

--- a/client/app/controllers/auth.controller.js
+++ b/client/app/controllers/auth.controller.js
@@ -64,6 +64,11 @@ function AuthController($window, $location, SigninService, SignupService) {
 
   }
 
+  vm.enterPressed = enterPressed;
+  function enterPressed(keyEvent, userInfo) {
+    if (keyEvent.which === 13) submitSignIn(userInfo);
+  }
+
 
 }
 

--- a/client/app/pages/signin.html
+++ b/client/app/pages/signin.html
@@ -10,8 +10,12 @@
             </div>
             <div class="account-wall">
                 <form class="form-signin">
-                    <input type="text" id="signinEmail" class="form-control" placeholder="Email" required autofocus ng-model="AU.userInfo.email">
-                    <input type="password" id="signinPassword" class="form-control" placeholder="Password" required ng-model="AU.userInfo.password">
+                    <input type="text" id="signinEmail" class="form-control"
+                    placeholder="Email" required autofocus
+                    ng-model="AU.userInfo.email" ng-keypress="AU.enterPressed
+                    ($event, AU.userInfo)">
+                    <input type="password" id="signinPassword" class="form-control" placeholder="Password" required ng-model="AU.userInfo.password" ng-keypress="AU.enterPressed
+                    ($event, AU.userInfo)">
                     <button class="btn btn-lg btn-primary btn-block" id="signin" type="button" ng-click="AU.submit(AU.userInfo)">
                         Sign in</button>
                     <label class="checkbox pull-left">

--- a/server/controllers/quotes.controller.js
+++ b/server/controllers/quotes.controller.js
@@ -348,4 +348,44 @@ router.put('/:id', function(req, res){
 
 }); //end of PUT route for priced quotes
 
+// PUT = update or create statusType of quote - ADMIN ONLY
+router.put('/:id/statusTypeId=:statusTypeId', function(req, res) {
+  // check for admin role first
+
+  // check for id parameter
+  if (req.params.id) {
+    // statusTypeId must be an integer in the set {1,4}
+    // this regex should be changed if we add or remove status type ids to the DB
+    if (req.params.statusTypeId && req.params.statusTypeId.match(/^[1-4]$/)) {
+
+      models.Order_Status
+        .update({
+          StatusTypeId: req.params.statusTypeId
+        }, {
+          where: {
+            OrderId: req.params.id,
+            current: true
+          }
+        })
+        .then(function(result) {
+          console.log(result);
+          // assuming we want to send some notification to someone here...
+          // send updated status notification to someone via email
+          // TWILIO API integration needed!!
+
+          // send updated quote back to client to update admin's view
+          res.json({updatedQuote: result});
+        })
+        .catch(function(err){
+          res.json({error: err});
+        });
+
+    } else {
+      res.status(403).json({error: 'Resource expects statusTypeId parameter in set {1,4}'});
+    }
+  } else {
+    res.status(403).json({error: 'Resource expects id parameter'});
+  }
+}); //end of PUT route for quote statusType
+
 module.exports = router;

--- a/server/docs/readMe.md
+++ b/server/docs/readMe.md
@@ -30,6 +30,10 @@ can be used by any role, creates new quote record at stage ‘requested’
 
 **PUT /quotes/{id}** - admin only, quote ‘id' is required, used for adding prices to requested quotes
 
+**PUT /quotes/{id}/statusTypeId={statusTypeId}** - admin only, quote 'id' is
+required, statusTypeId is required to be an integer within the set {1,4}, used
+for updating or creating statusTypeId of a quote
+
 ### Orders
 **GET /orders/{placed or shipped}**
 admin only, gets all current order records. If parameter “placed” or “shipped” is used will only return that type of order


### PR DESCRIPTION
This is a new PUT API route at /quotes/:id/statusTypeId=:statusTypeId

Finds, quote with the given id, and updated the statusTypeId to the given STid (given the STid is within the set {1,4} as those are the only available statusTypeIds at present)

This fulfills the task at: https://trello.com/c/BDWEZHPi/53-api-can-update-and-create-new-quote-status

---

Also, added ng-keypress events on the client/pages/signin.html input elements.

This ng-keypress triggers a function on the auth controller `enterPressed(event, userInfo)` and passes the userInfo to the controller's signin function if the event key is the ENTER key.

This fulfilles the task at: https://trello.com/c/STuNPlXh/58-login-form-should-trigger-submit-on-enter-key-press
